### PR TITLE
Fix SSE handling, JSON processing, and error handling (v0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1-alpha] - 2025-02-28
+
+### Fixed
+- Implemented proper Server-Sent Events (SSE) parsing to handle the API's event stream format
+- Fixed JSON response handling in `DownloadCrawlRequest` to support both object and array responses
+- Resolved "no result received" errors that occurred with certain API responses
+- Enhanced error handling throughout the SDK to prevent resource leaks
+- Improved response body closing to ensure all HTTP connections are properly released
+- Added better error propagation and contextual error messages
+- Fixed race conditions in asynchronous event processing
+
+### Added
+- Support for "state" events in addition to "result" events
+- Fallback mechanism to use state data when no result events are received
+- Better progress tracking and reporting
+- Enhanced debugging output with detailed request and response logging
+- More comprehensive error messages from API responses
+- Improved context support for better timeout and cancellation handling
+- Additional test cases for error conditions and edge cases
+
+### Changed
+- Modified `MonitorCrawlRequest` to use `bufio.Reader` for proper line-by-line reading
+- Updated `ScrapeURL` to handle various event types (state, progress, result, error)
+- Improved `processResponse` to extract more useful error information
+- Enhanced test suite with more comprehensive test cases
+- Updated error handling in all test code for better diagnostics
+- Improved logging to provide more context in error situations
+
+### Security
+- Added proper resource cleanup to prevent potential memory leaks
+- Improved timeout handling for network operations
+- Enhanced error checking for all I/O operations
+- Added safeguards against unclosed resources
+
 ## [0.1.0] - 2024-03-14
 
 ### Added
@@ -15,4 +49,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for downloading crawl results
 - Comprehensive documentation and examples
 - MIT License
-- Contributing guidelines 
+- Contributing guidelines

--- a/api_test.go
+++ b/api_test.go
@@ -3,9 +3,12 @@ package watercrawl
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestClient_GetCrawlRequests(t *testing.T) {
@@ -37,7 +40,9 @@ func TestClient_GetCrawlRequests(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Errorf("Failed to encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -81,7 +86,9 @@ func TestClient_CreateCrawlRequest(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Errorf("Failed to encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -141,15 +148,53 @@ func TestClient_ScrapeURL(t *testing.T) {
 				Status: "pending",
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(response)
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				t.Errorf("Failed to encode response: %v", err)
+			}
 		case "/api/v1/core/crawl-requests/test-uuid/status/":
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(EventStreamMessage{
+			// Set SSE headers
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+
+			// Send state event
+			stateData, err := json.Marshal(EventStreamMessage{
+				Type: "state",
+				Data: map[string]interface{}{
+					"uuid":   "test-uuid",
+					"url":    "https://example.com",
+					"status": "running",
+				},
+			})
+			if err != nil {
+				t.Errorf("Failed to marshal state data: %v", err)
+			}
+
+			_, err = fmt.Fprintf(w, "data: %s\n\n", stateData)
+			if err != nil {
+				t.Errorf("Failed to write state event: %v", err)
+			}
+
+			// Send result event
+			eventData, err := json.Marshal(EventStreamMessage{
 				Type: "result",
 				Data: map[string]interface{}{
 					"content": "test content",
 				},
 			})
+			if err != nil {
+				t.Errorf("Failed to marshal result data: %v", err)
+			}
+
+			_, err = fmt.Fprintf(w, "data: %s\n\n", eventData)
+			if err != nil {
+				t.Errorf("Failed to write result event: %v", err)
+			}
+
+			// Flush data immediately
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
 		}
 	}))
 	defer server.Close()
@@ -168,6 +213,265 @@ func TestClient_ScrapeURL(t *testing.T) {
 	}
 }
 
+func TestClient_ScrapeURL_StateOnly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/core/crawl-requests/":
+			response := CrawlRequest{
+				UUID:   "test-uuid",
+				Status: "pending",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				t.Errorf("Failed to encode response: %v", err)
+			}
+		case "/api/v1/core/crawl-requests/test-uuid/status/":
+			// Set SSE headers
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+
+			// Send state event with completed status
+			stateData, err := json.Marshal(EventStreamMessage{
+				Type: "state",
+				Data: map[string]interface{}{
+					"uuid":   "test-uuid",
+					"url":    "https://example.com",
+					"status": "completed",
+				},
+			})
+			if err != nil {
+				t.Errorf("Failed to marshal state data: %v", err)
+			}
+
+			_, err = fmt.Fprintf(w, "data: %s\n\n", stateData)
+			if err != nil {
+				t.Errorf("Failed to write state event: %v", err)
+			}
+
+			// No result event, only state
+
+			// Flush data immediately
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", server.URL+"/")
+	ctx := context.Background()
+
+	result, err := client.ScrapeURL(ctx, "https://example.com", nil, nil, true, false)
+	if err != nil {
+		t.Fatalf("ScrapeURL() error = %v", err)
+	}
+
+	// Check if we got the state data
+	status, ok := result["status"].(string)
+	if !ok || status != "completed" {
+		t.Errorf("ScrapeURL() status = %v, want completed", status)
+	}
+}
+
+func TestClient_MonitorCrawlRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/core/crawl-requests/test-uuid/status/" {
+			t.Errorf("Expected path /api/v1/core/crawl-requests/test-uuid/status/, got %s", r.URL.Path)
+		}
+
+		// Set SSE headers
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		// Send multiple SSE events
+		// State event
+		stateData, err := json.Marshal(EventStreamMessage{
+			Type: "state",
+			Data: map[string]interface{}{
+				"uuid":   "test-uuid",
+				"status": "running",
+			},
+		})
+		if err != nil {
+			t.Errorf("Failed to marshal state data: %v", err)
+		}
+
+		_, err = fmt.Fprintf(w, "data: %s\n\n", stateData)
+		if err != nil {
+			t.Errorf("Failed to write state event: %v", err)
+		}
+
+		// Progress event
+		progressData, err := json.Marshal(EventStreamMessage{
+			Type: "progress",
+			Data: map[string]interface{}{
+				"progress": 50.0,
+			},
+		})
+		if err != nil {
+			t.Errorf("Failed to marshal progress data: %v", err)
+		}
+
+		_, err = fmt.Fprintf(w, "data: %s\n\n", progressData)
+		if err != nil {
+			t.Errorf("Failed to write progress event: %v", err)
+		}
+
+		// Result event
+		resultData, err := json.Marshal(EventStreamMessage{
+			Type: "result",
+			Data: map[string]interface{}{
+				"content": "test content",
+			},
+		})
+		if err != nil {
+			t.Errorf("Failed to marshal result data: %v", err)
+		}
+
+		_, err = fmt.Fprintf(w, "data: %s\n\n", resultData)
+		if err != nil {
+			t.Errorf("Failed to write result event: %v", err)
+		}
+
+		// Flush data immediately
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", server.URL+"/")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	events, err := client.MonitorCrawlRequest(ctx, "test-uuid", false)
+	if err != nil {
+		t.Fatalf("MonitorCrawlRequest() error = %v", err)
+	}
+
+	// Read the first event (state)
+	event1 := <-events
+	if event1.Type != "state" {
+		t.Errorf("Expected first event type 'state', got %s", event1.Type)
+	}
+
+	// Read the second event (progress)
+	event2 := <-events
+	if event2.Type != "progress" {
+		t.Errorf("Expected second event type 'progress', got %s", event2.Type)
+	}
+
+	progressData, ok := event2.Data.(map[string]interface{})
+	if !ok {
+		t.Errorf("Expected progress data to be map, got %T", event2.Data)
+	} else {
+		progress, ok := progressData["progress"].(float64)
+		if !ok || progress != 50.0 {
+			t.Errorf("Expected progress value 50.0, got %v", progressData["progress"])
+		}
+	}
+
+	// Read the third event (result)
+	event3 := <-events
+	if event3.Type != "result" {
+		t.Errorf("Expected third event type 'result', got %s", event3.Type)
+	}
+
+	resultData, ok := event3.Data.(map[string]interface{})
+	if !ok {
+		t.Errorf("Expected result data to be map, got %T", event3.Data)
+	} else {
+		content, ok := resultData["content"].(string)
+		if !ok || content != "test content" {
+			t.Errorf("Expected content 'test content', got %v", resultData["content"])
+		}
+	}
+}
+
+func TestClient_DownloadCrawlRequest_Object(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected method GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/core/crawl-requests/test-uuid/download/" {
+			t.Errorf("Expected path /api/v1/core/crawl-requests/test-uuid/download/, got %s", r.URL.Path)
+		}
+
+		// Return object JSON
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"content":"test content","metadata":{"url":"https://example.com"}}`))
+		if err != nil {
+			t.Errorf("Failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", server.URL+"/")
+	ctx := context.Background()
+
+	result, err := client.DownloadCrawlRequest(ctx, "test-uuid")
+	if err != nil {
+		t.Fatalf("DownloadCrawlRequest() error = %v", err)
+	}
+
+	content, ok := result["content"].(string)
+	if !ok || content != "test content" {
+		t.Errorf("DownloadCrawlRequest() content = %v, want %v", content, "test content")
+	}
+}
+
+func TestClient_DownloadCrawlRequest_Array(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected method GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/core/crawl-requests/test-uuid/download/" {
+			t.Errorf("Expected path /api/v1/core/crawl-requests/test-uuid/download/, got %s", r.URL.Path)
+		}
+
+		// Return array JSON
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`[{"content":"item1"},{"content":"item2"}]`))
+		if err != nil {
+			t.Errorf("Failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient("test-key", server.URL+"/")
+	ctx := context.Background()
+
+	result, err := client.DownloadCrawlRequest(ctx, "test-uuid")
+	if err != nil {
+		t.Fatalf("DownloadCrawlRequest() error = %v", err)
+	}
+
+	// Check if we have results key
+	results, ok := result["results"].([]interface{})
+	if !ok {
+		t.Errorf("DownloadCrawlRequest() results not found or not an array")
+		return
+	}
+
+	if len(results) != 2 {
+		t.Errorf("DownloadCrawlRequest() results length = %v, want %v", len(results), 2)
+	}
+
+	// Check first item content
+	item1, ok := results[0].(map[string]interface{})
+	if !ok {
+		t.Errorf("DownloadCrawlRequest() results[0] not a map")
+		return
+	}
+
+	content1, ok := item1["content"].(string)
+	if !ok || content1 != "item1" {
+		t.Errorf("DownloadCrawlRequest() results[0].content = %v, want %v", content1, "item1")
+	}
+}
+
 func TestClient_CreateCrawlRequest_Validation(t *testing.T) {
 	client := NewClient("test-key", "")
 	ctx := context.Background()
@@ -180,7 +484,7 @@ func TestClient_CreateCrawlRequest_Validation(t *testing.T) {
 		{
 			name: "nil URL",
 			input: CreateCrawlRequestInput{
-				URL: nil,
+				URL:     nil,
 				Options: CrawlOptions{},
 			},
 			expectedError: "watercrawl: validation error: url: URL is required",
@@ -188,7 +492,7 @@ func TestClient_CreateCrawlRequest_Validation(t *testing.T) {
 		{
 			name: "empty string URL",
 			input: CreateCrawlRequestInput{
-				URL: "",
+				URL:     "",
 				Options: CrawlOptions{},
 			},
 			expectedError: "watercrawl: validation error: url: URL cannot be empty",
@@ -196,7 +500,7 @@ func TestClient_CreateCrawlRequest_Validation(t *testing.T) {
 		{
 			name: "empty string array URL",
 			input: CreateCrawlRequestInput{
-				URL: []string{},
+				URL:     []string{},
 				Options: CrawlOptions{},
 			},
 			expectedError: "watercrawl: validation error: url: URL list cannot be empty",
@@ -204,7 +508,7 @@ func TestClient_CreateCrawlRequest_Validation(t *testing.T) {
 		{
 			name: "array with empty string URL",
 			input: CreateCrawlRequestInput{
-				URL: []string{"https://example.com", ""},
+				URL:     []string{"https://example.com", ""},
 				Options: CrawlOptions{},
 			},
 			expectedError: "watercrawl: validation error: url[1]: URL cannot be empty",
@@ -212,7 +516,7 @@ func TestClient_CreateCrawlRequest_Validation(t *testing.T) {
 		{
 			name: "invalid URL type",
 			input: CreateCrawlRequestInput{
-				URL: 123,
+				URL:     123,
 				Options: CrawlOptions{},
 			},
 			expectedError: "watercrawl: validation error: url: URL must be a string or array of strings",
@@ -237,9 +541,11 @@ func TestClient_APIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{
+		if err := json.NewEncoder(w).Encode(map[string]string{
 			"error": "Invalid request parameters",
-		})
+		}); err != nil {
+			t.Errorf("Failed to encode error response: %v", err)
+		}
 	}))
 	defer server.Close()
 
@@ -252,7 +558,8 @@ func TestClient_APIError(t *testing.T) {
 		return
 	}
 
-	apiErr, ok := err.(*APIError)
+	var apiErr *APIError
+	ok := errors.As(err, &apiErr)
 	if !ok {
 		t.Errorf("Expected APIError, got %T", err)
 		return
@@ -266,4 +573,4 @@ func TestClient_APIError(t *testing.T) {
 	if apiErr.Message != expectedMessage {
 		t.Errorf("Expected message %q, got %q", expectedMessage, apiErr.Message)
 	}
-} 
+}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package watercrawl
 
 // Version is the current version of the WaterCrawl Go SDK
-const Version = "0.1.0" 
+const Version = "0.1.1-alpha"


### PR DESCRIPTION
This commit addresses several issues encountered when working with the WaterCrawl API and implements comprehensive error handling throughout the SDK:

1. Implement proper Server-Sent Events (SSE) parsing:
   - Replace direct JSON decoding with line-by-line reading using bufio.Reader
   - Correctly handle "data:" prefixed event messages in SSE format
   - Add proper debugging output for better troubleshooting during crawl operations
   - Fix event stream processing to properly handle connection interruptions

2. Improve result handling:
   - Update DownloadCrawlRequest to handle both object and array responses from API
   - Add array-to-map conversion for consistent return types across all endpoints
   - Add better error reporting when downloading results
   - Fix race conditions in asynchronous result processing

3. Enhance event type support:
   - Add handling for "state" events in addition to "result" events
   - Track state data to provide fallback when no result event is received
   - Add support for progress tracking and detailed error reporting
   - Improve cancellation handling with proper context support

4. Implement comprehensive error handling:
   - Fix all unhandled errors throughout the codebase
   - Add proper resource cleanup with error checking
   - Improve response body closing to prevent resource leaks
   - Add detailed error context to all error messages

5. Add comprehensive test suite:
   - Test SSE parsing with proper data format
   - Verify handling of multiple event types (state, progress, result)
   - Test both object and array download response formats
   - Add error handling to all test code
   - Improve test reliability and error reporting

These changes make the SDK more robust when communicating with the WaterCrawl API, prevent resource leaks, and provide better error messages for troubleshooting. The improved SSE handling addresses the root cause of "no result received" errors that could occur with certain API responses.

Version bump: 0.1.0 -> 0.1.1-alpha